### PR TITLE
Add STEP component visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Component Visualizer
+
+This repository contains a simple Python script that loads a STEP (`.stp`) file and generates a PNG image for each solid found in the model. The script is intended to demonstrate basic 3D model handling and works on macOS (including Apple silicon) as well as Linux and Windows, assuming the required dependencies are installed.
+
+## Requirements
+
+- Python 3.8+
+- [`pythonocc-core`](https://pypi.org/project/pythonocc-core/)
+- `PyQt5` or `PyQt6` (required by `pythonocc-core` for visualization)
+
+Install the dependencies with `pip`:
+
+```bash
+pip install pythonocc-core PyQt5
+```
+
+On Apple silicon Macs you may need to install `pythonocc-core` via [conda](https://docs.conda.io/) or build it from source if the wheel is not available on PyPI.
+
+## Usage
+
+Run the script with the path to a STEP file and the desired output directory:
+
+```bash
+python component_visualizer.py path/to/model.stp output_folder
+```
+
+Each solid in the STEP file will be rendered to a separate PNG inside `output_folder`.
+
+## Notes
+
+If you run the script on a headless system or wish to suppress the GUI window, set the environment variable `QT_QPA_PLATFORM=offscreen` before running the script:
+
+```bash
+QT_QPA_PLATFORM=offscreen python component_visualizer.py model.stp out
+```

--- a/component_visualizer.py
+++ b/component_visualizer.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+from OCC.Core.STEPControl import STEPControl_Reader
+from OCC.Core.IFSelect import IFSelect_RetDone
+from OCC.Core.TopExp import TopExp_Explorer
+from OCC.Core.TopAbs import TopAbs_SOLID
+from OCC.Display.SimpleGui import init_display
+
+
+def load_step(path: str):
+    """Load a STEP file and return the resulting shape."""
+    reader = STEPControl_Reader()
+    status = reader.ReadFile(path)
+    if status != IFSelect_RetDone:
+        raise RuntimeError(f"Failed to read STEP file: {path}")
+    reader.TransferRoots()
+    return reader.OneShape()
+
+
+def iter_solids(shape):
+    """Yield each solid found in the shape."""
+    exp = TopExp_Explorer(shape, TopAbs_SOLID)
+    while exp.More():
+        yield exp.Current()
+        exp.Next()
+
+
+def save_component_images(step_path: str, out_dir: str):
+    """Save each solid from the STEP file as a PNG screenshot."""
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    shape = load_step(step_path)
+    solids = list(iter_solids(shape))
+
+    if not solids:
+        raise RuntimeError("No solids found in the STEP file")
+
+    display, start_display, add_menu, add_function_to_menu = init_display()
+
+    for i, solid in enumerate(solids, start=1):
+        display.EraseAll()
+        display.DisplayShape(solid, update=True)
+        display.FitAll()
+        img_path = os.path.join(out_dir, f"component_{i}.png")
+        display.View.Dump(img_path)
+        print(f"Saved {img_path}")
+
+    display.Close()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate screenshots for each component in a STEP file"
+    )
+    parser.add_argument("step_file", help="Path to the STEP/STP file")
+    parser.add_argument("output_dir", help="Directory where PNG files will be saved")
+    args = parser.parse_args()
+
+    save_component_images(args.step_file, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a component visualizer script for STEP files
- document usage and dependencies

## Testing
- `python component_visualizer.py --help` *(fails: ModuleNotFoundError: No module named 'OCC')*

------
https://chatgpt.com/codex/tasks/task_e_68426a066414832db8af381c0370ef1a