### PR TITLE
Add directory support to STEP visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Component Visualizer
+
+This repository contains a simple Python script that loads a STEP (`.stp`) file and generates a PNG image for each solid found in the model. The script is intended to demonstrate basic 3D model handling and works on macOS (including Apple silicon) as well as Linux and Windows, assuming the required dependencies are installed.
+
+## Requirements
+
+- Python 3.8+
+- [`pythonocc-core`](https://pypi.org/project/pythonocc-core/)
+- `PyQt5` or `PyQt6` (required by `pythonocc-core` for visualization)
+
+Install the dependencies with `pip`:
+
+```bash
+pip install pythonocc-core PyQt5
+```
+
+On Apple silicon Macs you may need to install `pythonocc-core` via [conda](https://docs.conda.io/) or build it from source if the wheel is not available on PyPI.
+
+## Usage
+
+Run the script with the path to a STEP file or a directory containing multiple STEP files. Each part detected in the file is exported as a PNG using the part name. Images are saved inside a folder named after the STEP file:
+
+```bash
+python component_visualizer.py path/or/folder output_folder
+```
+
+Use `--recursive` to search subdirectories for STEP files. Each component is stored as `output_folder/<step_name>/<component_name>.png`.
+
+## Notes
+
+If you run the script on a headless system or wish to suppress the GUI window, set the environment variable `QT_QPA_PLATFORM=offscreen` before running the script:
+
+```bash
+QT_QPA_PLATFORM=offscreen python component_visualizer.py model.stp out
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On Apple silicon Macs you may need to install `pythonocc-core` via [conda](https
 
 ## Usage
 
-Run the script with the path to a STEP file or a directory containing multiple STEP files. Each part detected in the file is exported as a PNG using the part name. Images are saved inside a folder named after the STEP file:
+Run the script with the path to a STEP file or a directory containing multiple STEP files. The script extracts the original component names from the STEP data and saves a PNG of each solid using that name. Images are stored inside a folder named after the STEP file:
 
 ```bash
 python component_visualizer.py path/or/folder output_folder

--- a/component_visualizer.py
+++ b/component_visualizer.py
@@ -1,0 +1,129 @@
+import argparse
+import os
+from typing import Iterable, Tuple
+
+from OCC.Core.STEPCAFControl import STEPCAFControl_Reader
+from OCC.Core.IFSelect import IFSelect_RetDone
+from OCC.Display.SimpleGui import init_display
+from OCC.Core.XCAFApp import XCAFApp_Application
+from OCC.Core.TDocStd import TDocStd_Document
+from OCC.Core.TCollection import TCollection_ExtendedString
+from OCC.Core.XCAFDoc import XCAFDoc_DocumentTool
+from OCC.Core.TDataStd import TDataStd_Name
+from OCC.Core.TDF import TDF_LabelSequence
+
+
+def load_components(path: str) -> Iterable[Tuple[object, str]]:
+    """Load a STEP file and return each top-level shape with its name."""
+    app = XCAFApp_Application.GetApplication()
+    doc = TDocStd_Document(TCollection_ExtendedString("pythonocc-doc"))
+    app.NewDocument("MDTV-XCAF", doc)
+
+    reader = STEPCAFControl_Reader()
+    reader.SetNameMode(True)
+    status = reader.ReadFile(path)
+    if status != IFSelect_RetDone:
+        raise RuntimeError(f"Failed to read STEP file: {path}")
+
+    if not reader.Transfer(doc):
+        raise RuntimeError("Failed to transfer STEP contents")
+
+    shape_tool = XCAFDoc_DocumentTool.ShapeTool(doc.Main())
+    labels = TDF_LabelSequence()
+    shape_tool.GetFreeShapes(labels)
+
+    components = []
+    for i in range(labels.Length()):
+        lbl = labels.Value(i + 1)
+        shape = shape_tool.GetShape(lbl)
+        name_attr = TDataStd_Name()
+        name = f"component_{i+1}"
+        if lbl.FindAttribute(TDataStd_Name.GetID(), name_attr):
+            name = name_attr.Get().ToExtString()
+        components.append((shape, name))
+
+    return components
+
+
+def save_component_images(step_path: str, out_dir: str) -> Iterable[str]:
+    """Save each solid from the STEP file as a PNG screenshot.
+
+    Returns an iterable of paths to the saved images."""
+    if not os.path.exists(out_dir):
+        os.makedirs(out_dir)
+
+    components = list(load_components(step_path))
+
+    if not components:
+        raise RuntimeError("No solids found in the STEP file")
+
+    display, start_display, add_menu, add_function_to_menu = init_display()
+    saved = []
+    for i, (solid, name) in enumerate(components, start=1):
+        display.EraseAll()
+        display.DisplayShape(solid, update=True)
+        display.FitAll()
+        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+        if not safe:
+            safe = f"component_{i}"
+        img_path = os.path.join(out_dir, f"{safe}.png")
+        display.View.Dump(img_path)
+        saved.append(img_path)
+        print(f"Saved {img_path}")
+
+    return saved
+
+
+def iter_step_files(path: str, recursive: bool = False) -> Iterable[str]:
+    """Yield all .stp or .step files from a file or directory path."""
+    if os.path.isfile(path):
+        return [path]
+
+    step_exts = {".stp", ".step", ".STEP", ".STP"}
+    files = []
+    if recursive:
+        for root, _, filenames in os.walk(path):
+            for fname in filenames:
+                if os.path.splitext(fname)[1] in step_exts:
+                    files.append(os.path.join(root, fname))
+    else:
+        for fname in os.listdir(path):
+            if os.path.splitext(fname)[1] in step_exts:
+                files.append(os.path.join(path, fname))
+    return files
+
+
+def process_path(step_path: str, output_dir: str, recursive: bool = False):
+    """Process a STEP file or all STEP files in a directory."""
+    files = iter_step_files(step_path, recursive=recursive)
+    for fpath in files:
+        base = os.path.splitext(os.path.basename(fpath))[0]
+        out = os.path.join(output_dir, base)
+        print(f"Processing {fpath}")
+        save_component_images(fpath, out)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate screenshots for each component in STEP files",
+    )
+    parser.add_argument(
+        "path",
+        help="Path to a STEP/STP file or a directory containing STEP files",
+    )
+    parser.add_argument(
+        "output_dir",
+        help="Directory where PNG files will be saved",
+    )
+    parser.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Recursively search for STEP files in subdirectories",
+    )
+    args = parser.parse_args()
+
+    process_path(args.path, args.output_dir, recursive=args.recursive)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- update README with directory usage instructions
- enhance `component_visualizer.py` to handle folders of STEP files

## Testing
- `python component_visualizer.py --help` *(fails: ModuleNotFoundError: No module named 'OCC')*

------
https://chatgpt.com/codex/tasks/task_e_68426a066414832db8af381c0370ef1a